### PR TITLE
disable proxy when useProxy is none

### DIFF
--- a/src/common/request.ts
+++ b/src/common/request.ts
@@ -22,7 +22,10 @@ export function requestVault(requestedUrl: string, ignoreCertificateChecks: bool
 			strNamespaces = "";
         }
 
-        if(useProxy != "none"){
+        if(useProxy == "none"){
+            options["proxy"] = false;
+        }        
+        else {
             options["proxy"] = {
                 protocol: useProxy,
                 host: strProxyHost,


### PR DESCRIPTION
when useProxy is none , axios proxy should be set to false otherwise axios will load the HTTP_PROXY variables and the request will be passed through proxy.
